### PR TITLE
Allow dynamic parameters in DSN

### DIFF
--- a/src/DI/MessengerExtension.php
+++ b/src/DI/MessengerExtension.php
@@ -97,7 +97,7 @@ class MessengerExtension extends CompilerExtension
 			),
 			'transport' => Expect::arrayOf(
 				Expect::structure([
-					'dsn' => Expect::string()->required(),
+					'dsn' => Expect::string()->required()->dynamic(),
 					'options' => Expect::array(),
 					'serializer' => $expectService,
 					'failureTransport' => Expect::string(),

--- a/tests/Cases/DI/MessengerExtension.transport.phpt
+++ b/tests/Cases/DI/MessengerExtension.transport.phpt
@@ -127,3 +127,22 @@ Toolkit::test(function (): void {
 
 	Assert::count(1, $container->findByTag(MessengerExtension::FAILURE_TRANSPORT_TAG));
 });
+
+// Dynamic parameters
+Toolkit::test(function (): void {
+	$container = Container::of()
+		->withDefaults()
+		->withDynamicParameters(['sync_dsn' => 'sync://'])
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addConfig(Helpers::neon(<<<'NEON'
+				messenger:
+					transport:
+						sync:
+							dsn: %sync_dsn%
+			NEON
+			));
+		})
+		->build();
+
+	Assert::type(SyncTransport::class, $container->getByName('messenger.transport.sync'));
+});


### PR DESCRIPTION
Im not sure, whether dynamic parameters on other settings, like `options` makes sense, maybe yes.  In my usecase DSN is in env variable.

Before: 
<img width="1318" alt="Screenshot 2023-07-15 at 0 05 08" src="https://github.com/contributte/messenger/assets/3995003/a75c6782-5923-443e-a3fb-789146850a2c">

After:  
❤️ 