### PR TITLE
Draft: Messages without routing are now handled immediately instead of throwing exception

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -68,14 +68,7 @@ extensions:
 Minimal configuration example:
 
 ```neon
-messenger:
-    transport:
-        sync:
-            dsn: "sync://"
-
-    routing:
-        App\Domain\SimpleMessage: [sync]
-
+# Just register the handler as a service to DIC
 services:
     - App\Domain\SimpleMessageHandler
 ```
@@ -178,6 +171,7 @@ messenger:
             dsn: doctrine://postgres:password@localhost:5432?queue_name=failed
 
     # Defines routing (message -> transport)
+    # If the routing for message is missing, the message will be handler by handler immediately when dispatched
     routing:
         App\Domain\NewUserEmail: [redis]
         App\Domain\ForgotPasswordEmail: [db, redis]

--- a/tests/Cases/DI/MessengerExtension.routing.phpt
+++ b/tests/Cases/DI/MessengerExtension.routing.phpt
@@ -52,6 +52,31 @@ Toolkit::test(function (): void {
 	Assert::equal('foobar', $handler->message->text);
 });
 
+// Message without routing - handle immediately
+Toolkit::test(function (): void {
+	$container = Container::of()
+		->withDefaults()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addConfig(Helpers::neon(<<<'NEON'
+				services:
+					- Tests\Mocks\Handler\SimpleHandler
+			NEON
+			));
+		})
+		->build();
+
+	/** @var BusRegistry $busRegistry */
+	$busRegistry = $container->getByType(BusRegistry::class);
+	$messageBus = $busRegistry->get('messageBus');
+
+	$messageBus->dispatch(new SimpleMessage('foobar'));
+
+	/** @var SimpleHandler $handler */
+	$handler = $container->getByType(SimpleHandler::class);
+
+	Assert::equal('foobar', $handler->message->text);
+});
+
 // No handler
 Toolkit::test(function (): void {
 	$container = Container::of()


### PR DESCRIPTION
This PR brings behaviour that is documented in the official [symfony/messenger docs](https://symfony.com/doc/current/messenger.html#handling-messages-synchronously):  

<img width="795" alt="Screenshot 2023-08-06 at 18 33 41" src="https://github.com/contributte/messenger/assets/3995003/9d1923a2-9671-4f9c-8abc-cbd2d9c7949b">
