### PR TITLE
Middlewares are now like in Symfony + can disable default middlewares

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -91,6 +91,9 @@ messenger:
     # Defines buses, default one are messageBus, queryBus and commandBus.
     bus:
         messageBus:
+            # To disable default middlewares stack (see https://symfony.com/doc/current/messenger.html#middleware)
+            defaultMiddlewares: false
+
             # Define middlewares just for this bus.
             middlewares:
                 #- LoggerMiddleware()

--- a/src/DI/MessengerExtension.php
+++ b/src/DI/MessengerExtension.php
@@ -76,6 +76,7 @@ class MessengerExtension extends CompilerExtension
 			]),
 			'bus' => Expect::arrayOf(
 				Expect::structure([
+					'defaultMiddlewares' => Expect::bool(true),
 					'middlewares' => Expect::arrayOf($expectService),
 					'allowNoHandlers' => Expect::bool(false),
 					'allowNoSenders' => Expect::bool(true),
@@ -85,6 +86,7 @@ class MessengerExtension extends CompilerExtension
 				Expect::string()->required(),
 			)->default(ArrayHash::from([
 				'messageBus' => [
+					'defaultMiddlewares' => true,
 					'middlewares' => [],
 					'class' => null,
 					'autowired' => true,

--- a/tests/Cases/DI/MessengerExtension.transport.phpt
+++ b/tests/Cases/DI/MessengerExtension.transport.phpt
@@ -27,7 +27,7 @@ Toolkit::test(function (): void {
 		->build();
 
 	Assert::count(1, $container->findByType(SerializerInterface::class));
-	Assert::count(4, $container->findByType(MiddlewareInterface::class));
+	Assert::count(5, $container->findByType(MiddlewareInterface::class));
 	Assert::count(5, $container->findByType(TransportFactoryInterface::class));
 	Assert::count(0, $container->findByType(TransportInterface::class));
 });


### PR DESCRIPTION
- Added `DispatchAfterCurrentBusMiddleware` to the stack
- Added `defaultMiddlewares: bool` configuration to the bus to be able to disable default middlewares
- Custom user middlewares are now in between

### Before:
- ... custom middlewares ...
- `AddBusNameStampMiddleware`
- `FailedMessageProcessingMiddleware`
- `SendMessageMiddleware`
- `HandleMessageMiddleware`

### After:

as described in [symfony docs](https://symfony.com/doc/current/messenger.html#middleware)

- `AddBusNameStampMiddleware`
- `FailedMessageProcessingMiddleware`
- `DispatchAfterCurrentBusMiddleware`
- ... custom middlewares ...
- `SendMessageMiddleware`
- `HandleMessageMiddleware`
