### PR TITLE
Added support for batch messenger handlers

### DIFF
--- a/src/DI/Pass/HandlerPass.php
+++ b/src/DI/Pass/HandlerPass.php
@@ -69,11 +69,11 @@ class HandlerPass extends AbstractPass
 				/** @var AsMessageHandler $attributeHandler */
 				$attributeHandler = isset($attributes[0]) ? $attributes[0]->getArguments() : new stdClass();
 				$attributeOptions = [
-					'bus' => $attributeHandler['bus'] ?? null,
-					'method' => $attributeHandler['method'] ?? null,
-					'priority' => $attributeHandler['priority'] ?? null,
-					'handles' => $attributeHandler['handles'] ?? null,
-					'from_transport' => $attributeHandler['fromTransport'] ?? null,
+					'bus' => $attributeHandler->bus ?? null,
+					'method' => $attributeHandler->method ?? null,
+					'priority' => $attributeHandler->priority ?? null,
+					'handles' => $attributeHandler->handles ?? null,
+					'from_transport' => $attributeHandler->fromTransport ?? null,
 				];
 
 				// Complete final options

--- a/src/DI/Utils/Reflector.php
+++ b/src/DI/Utils/Reflector.php
@@ -55,11 +55,11 @@ final class Reflector
 			throw new LogicalException(sprintf('Handler must have "%s::%s()" method.', $class, $options['method']));
 		}
 
-		if ($rcMethod->getNumberOfParameters() !== 1 && !is_a($class, BatchHandlerInterface::class)) {
+		if ($rcMethod->getNumberOfParameters() !== 1 && !$rc->implementsInterface( BatchHandlerInterface::class)) {
 			throw new LogicalException(sprintf('Only one parameter is allowed in "%s::%s()."', $class, $options['method']));
 		}
 
-		if (is_a($class, BatchHandlerInterface::class)) {
+		if ($rc->implementsInterface( BatchHandlerInterface::class)) {
 			if ($rcMethod->getNumberOfParameters() !== 2) {
 				throw new LogicalException(sprintf('Exactly two parameters are required in "%s::%s()."', $class, $options['method']));
 			}


### PR DESCRIPTION
https://symfony.com/doc/current/messenger.html#process-messages-by-batches

Handlers then look like this:
```php
use Symfony\Component\Messenger\Handler\Acknowledger;
use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
use Symfony\Component\Messenger\Handler\BatchHandlerTrait;

final class MyHandler implements BatchHandlerInterface
{
    use BatchHandlerTrait;

    public function __invoke(MyMessage $message, null|Acknowledger $ack = null): mixed
    { 
       // ...
    }
}
```