### PR TITLE
StopWorkerOnSignalsListener is deprecated

### DIFF
--- a/src/DI/Pass/EventPass.php
+++ b/src/DI/Pass/EventPass.php
@@ -101,7 +101,7 @@ class EventPass extends AbstractPass
 			$dispatcher->addSetup('addSubscriber', [
 				new Statement(StopWorkerOnSignalsListener::class, [null, $this->prefix('@logger.logger')]),
 			]);
-		} else {
+		} elseif (class_exists(StopWorkerOnSigtermSignalListener::class)) {
 			$dispatcher->addSetup('addSubscriber', [
 				new Statement(StopWorkerOnSigtermSignalListener::class, [$this->prefix('@logger.logger')]), // @phpstan-ignore-line
 			]);


### PR DESCRIPTION
https://github.com/symfony/messenger/commit/ac70feca12468dd8740c863c4186a73aa59e03f6#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed

After this change it seems to be working correctly on version 7.3